### PR TITLE
remove reference to asm.jmpsub

### DIFF
--- a/arch/8051.md
+++ b/arch/8051.md
@@ -4,6 +4,7 @@ Using r2 with 8051
 Features
 --------
 - [x] Disassembler
+- [x] Assembler
 - [x] Emulation (esil)
 - [x] Basic address space mapping
 
@@ -13,7 +14,6 @@ Untested
 
 Missing
 -------
-- [ ] Assembler
 - [ ] Full emulation of memory-mapped registers
 - [ ] Memory banking for address spaces > 64K
 - [ ] Advanced analysis like local variables, function parameters ..
@@ -37,10 +37,6 @@ mapped memory. For example:
 e asm.cpu = 8051-generic
 aei
 ````
-
-Enable substitution of jumps, calls, and branches:
-
-`e asm.jmpsub = true`
 
 
 Address spaces and memory mapping


### PR DESCRIPTION
the asm.jmpsub option is apperantly outdated / enabled by default:
> \<pancake\> are you using r2 from the past?

also there's an assembler available, put that in the list.