### PR TITLE
Escape parenthesis in Markdown urls

### DIFF
--- a/analysis/types.md
+++ b/analysis/types.md
@@ -285,7 +285,7 @@ there are basically 3 mandatory keys for defining basic data types:
 `X=type`
 `type.X=format_specifier`
 `type.X.size=size_in_bits`
-For example, let's define `UNIT`, according to [Microsoft documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx#UINT )
+For example, let's define `UNIT`, according to [Microsoft documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751%28v=vs.85%29.aspx#UINT)
 `UINT` is just equivalent of standard C `unsigned int` (or `uint32_t` in terms of TCC engine).
 It will be defined as:
 

--- a/disassembling/esil.md
+++ b/disassembling/esil.md
@@ -1,6 +1,6 @@
 # ESIL
 
-ESIL stands for 'Evaluable Strings Intermediate Language'. It aims to describe a [Forth](https://en.wikipedia.org/wiki/Forth_(programming_language))-like representation for every target CPU opcode semantics. ESIL representations can be evaluated (interpreted) in order to emulate individual instructions. Each command of an ESIL expression is separated by a comma. Its virtual machine can be described as this:
+ESIL stands for 'Evaluable Strings Intermediate Language'. It aims to describe a [Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)-like representation for every target CPU opcode semantics. ESIL representations can be evaluated (interpreted) in order to emulate individual instructions. Each command of an ESIL expression is separated by a comma. Its virtual machine can be described as this:
 ```
    while ((word=haveCommand())) {
      if (word.isOperator()) {

--- a/scripting/intro.md
+++ b/scripting/intro.md
@@ -70,7 +70,7 @@ Radare2 also provides quite a few Unix type file processing commands like head, 
 [0x00404800]> uniq file > uniq_file
 ```
 
-The [head](https://en.wikipedia.org/wiki/Head_(Unix)) command can be used to see the first N number of lines in the file, similarly [tail](https://en.wikipedia.org/wiki/Tail_(Unix)) command allows the last N number of lines to be seen.
+The [head](https://en.wikipedia.org/wiki/Head_%28Unix%29) command can be used to see the first N number of lines in the file, similarly [tail](https://en.wikipedia.org/wiki/Tail_(Unix)) command allows the last N number of lines to be seen.
 ```
 [0x00404800]> head 3 foodtypes.txt
 1 Protein
@@ -81,7 +81,7 @@ The [head](https://en.wikipedia.org/wiki/Head_(Unix)) command can be used to see
 4 Milk
 ```
 
-The [join](https://en.wikipedia.org/wiki/Join_\(Unix\)) command could be used to merge two different files with comman first field. 
+The [join](https://en.wikipedia.org/wiki/Join_%28Unix%29) command could be used to merge two different files with comman first field. 
 ```
 [0x00404800]> cat foodtypes.txt
 1 Protein
@@ -97,7 +97,7 @@ The [join](https://en.wikipedia.org/wiki/Join_\(Unix\)) command could be used to
 3 Fat Butter
 ```
 
-Similarly, sorting the content is also possible with the [sort](https://en.wikipedia.org/wiki/Sort_\(Unix\)) command. A typical 
+Similarly, sorting the content is also possible with the [sort](https://en.wikipedia.org/wiki/Sort_%28Unix%29) command. A typical 
 example could be:
 ```
 [0x00404800]> sort file


### PR DESCRIPTION
Without escapting, the closing parenthesis of a url like
`https://en.wikipedia.org/wiki/Forth_(programming_language)`
would get interpreted as the closing symbol for an inline-style link
(resulting in incorrect link target and a superfluous closing
parenthesis behind the link).

For example, see first line of [1] which shows `Forth)-like` instead of `Forth-like` and links to a non-existing Wikipedia page.


[1] https://radare.gitbooks.io/radare2book/content/disassembling/esil.html