### PR TITLE
rearrange command line options

### DIFF
--- a/first_steps/overview.md
+++ b/first_steps/overview.md
@@ -47,7 +47,7 @@ $ rahash2 file
 file: 0x00000000-0x00000007 sha256: 887cfbd0d44aaff69f7bdbedebd282ec96191cce9d7fa7336298a18efc3c7a5a
 ```
 ```
-$ rahash2 file -a md5
+$ rahash2 -a md5 file
 file: 0x00000000-0x00000007 md5: d1833805515fc34b46c2b9de553f599d
 ```
 ### radiff2


### PR DESCRIPTION
The original version works well on Linux, but not on MacOS.
I get
```bash
$ rahash2 file -a md5
file: 0x00000000-0x000006ee sha256: 6042020f04d4b49b4f67efa49e28386a8d80a62fa65b498fabe581bb131ecc22
rahash2: Cannot open '-a'
```
on both bash and zsh.