### PR TITLE
Update variables.md: Change afvn syntax to [new_name] [old_name]

### DIFF
--- a/analysis/variables.md
+++ b/analysis/variables.md
@@ -17,7 +17,7 @@ The main variables commands are located in `afv` namespace:
 | afva                        analyze function arguments/locals
 | afvd name                   output r2 command for displaying the value of args/locals in the
 debugger
-| afvn [old_name] [new_name]  rename argument/local
+| afvn [new_name] [old_name]  rename argument/local
 | afvt [name] [new_type]      change type for given argument/local
 | afv-([name])                remove all or given var
 ```


### PR DESCRIPTION

**Detailed description**

The syntax for afvn is displayed as:
```
:> afv?~afvn
| afvn [new_name] ([old_name])  rename argument/local
```
It was last changed in [this commit](https://github.com/radareorg/radare2/commit/aa435d9a5748b2513cbfd0cd295930dd50f2161a) 

On the radare2book, it is still
```
| afvn [old_name] [new_name]  rename argument/local
```
---
I'm on radare2 4.5.0,
```
radare2 4.5.0-git 24580 @ linux-x86-64 git.4.4.0-111-gd7258113d
commit: d7258113d9332dbeb1da2134d3440480e966ae6b build: 2020-05-02__22:07:31
```