### PR TITLE
Fix Python asm plugin example.

### DIFF
--- a/plugins/python.md
+++ b/plugins/python.md
@@ -28,7 +28,7 @@ def mycpu(a):
             "name" : "mycpu",
             "arch" : "mycpu",
             "bits" : 32,
-            "endian" : "little",
+            "endian" : R.R_SYS_ENDIAN_LITTLE,
             "license" : "GPL",
             "desc" : "MYCPU disasm",
             "assemble" : assemble,


### PR DESCRIPTION

**Detailed description**

The asm plugin example does not correctly set endianness. _endian_ should be an int as defined here:
https://github.com/radareorg/radare2-rlang/blob/master/python/asm.c#L131
https://github.com/radareorg/radare2-rlang/blob/master/python/asm.c#L18

When starting radare (`r2 -I myplugin.py -a myarch`):
`TypeError: 'str' object cannot be interpreted as an integer`

And when disassembling radare prints:
`RAsmPlugin doesn't specify endianness`

**Test plan**

Verified the arch is listed (`e asm.arch = ?`) and is disassembling (`pd 1`). Both error logs above are gone.

**Closing issues**


