### PR TITLE
Update zignatures.md: Added information about the new commands in z

### DIFF
--- a/signatures/zignatures.md
+++ b/signatures/zignatures.md
@@ -7,16 +7,21 @@ create them on the fly. They are available under the `z` command namespace:
 [0x000100b0]> z?
 |Usage: z[*j-aof/cs] [args] # Manage zignatures
 | z            show zignatures
+| z.           find matching zignatures in current offset
 | z*           show zignatures in radare format
+| zq           show zignatures in quiet mode
 | zj           show zignatures in json format
+| zk           show zignatures in sdb format
 | z-zignature  delete zignature
 | z-*          delete all zignatures
 | za[?]        add zignature
+| zg           generate zignatures (alias for zaF)
 | zo[?]        manage zignature files
 | zf[?]        manage FLIRT signatures
 | z/[?]        search zignatures
-| zc           check zignatures at address
+| zc[?]        compare current zignspace zignatures with another one
 | zs[?]        manage zignspaces
+| zi           show zignatures matching information
 ```
 To load the created signature file you need to load it from SDB file using `zo` command or
 from the compressed SDB file using `zoz` command.


### PR DESCRIPTION

**Detailed description**
Help option of the `z` command, `z?` returned information about commands like `zq`, `zi` and `zq` which are not in the radare2book.

```
| z.           find matching zignatures in current offset
| zq           show zignatures in quiet mode
| zk           show zignatures in sdb format
| zg           generate zignatures (alias for zaF)
| zc[?]        compare current zignspace zignatures with another one
| zi           show zignatures matching information
```

I've added information about the new commands.

---
My version is :
```
radare2 4.5.0-git 24766 @ linux-x86-64 git.4.4.0-217-gd2e6b41e5
commit: d2e6b41e533aeae51d605697d7748f334f24db0c build: 2020-05-27__18:05:42
```
