### PR TITLE
Update command hints

### DIFF
--- a/analysis/types.md
+++ b/analysis/types.md
@@ -8,7 +8,7 @@ Most of the related commands are located in `t` namespace:
 
 ```
 [0x000051c0]> t?
-Usage: t   # cparse types commands
+| Usage: t   # cparse types commands
 | t                          List all loaded types
 | tj                         List all loaded types as json
 | t <type>                   Show type in 'pf' syntax
@@ -16,7 +16,7 @@ Usage: t   # cparse types commands
 | t- <name>                  Delete types by its name
 | t-*                        Remove all types
 | tail [filename]            Output the last part of files
-| tc[type.name]              List all/given types in C output format
+| tc [type.name]             List all/given types in C output format
 | te[?]                      List all loaded enums
 | td[?] <string>             Load types from string
 | tf                         List all loaded functions signatures
@@ -25,10 +25,11 @@ Usage: t   # cparse types commands
 | tn[?] [-][addr]            manage noreturn function attributes and marks
 | to -                       Open cfg.editor to load types
 | to <path>                  Load types from C header file
-| toe[type.name]             Open cfg.editor to edit types
+| toe [type.name]            Open cfg.editor to edit types
 | tos <path>                 Load types from parsed Sdb database
-| tp  <type> [addr|varname]  cast data at <address> to <type> and print it
-| tpx <type> <hexpairs>      Show value for type with specified byte sequence
+| tp  <type> [addr|varname]  cast data at <address> to <type> and print it (XXX: type can contain spaces)
+| tpv <type> @ [value]       Show offset formatted for given type
+| tpx <type> <hexpairs>      Show value for type with specified byte sequence (XXX: type can contain spaces)
 | ts[?]                      Print loaded struct types
 | tu[?]                      Print loaded union types
 | tx[f?]                     Type xrefs

--- a/basic_commands/block_size.md
+++ b/basic_commands/block_size.md
@@ -4,13 +4,16 @@ The block size determines how many bytes radare2 commands will process when not 
 
 ```
 [0xB7F9D810]> b?
-|Usage: b[f] [arg] Get/Set block size
-| b        display current block size
+| Usage: b[f] [arg]
+| Get/Set block size
 | b 33     set block size to 33
+| b eip+4  numeric argument can be an expression
+| b        display current block size
 | b+3      increase blocksize by 3
 | b-16     decrease blocksize by 16
-| b eip+4  numeric argument can be an expression
+| b*       display current block size in r2 command
 | bf foo   set block size to flag size
+| bj       display block size information in JSON
 | bm 1M    set max block size
 ```
 

--- a/basic_commands/comparing_bytes.md
+++ b/basic_commands/comparing_bytes.md
@@ -12,27 +12,30 @@ Inside r2, the functionalities exposed by radiff2 are available with the `c` com
 
 ```
 [0x00404888]> c?
- |Usage: c[?dfx] [argument] # Compare
- | c [string]       Compare a plain with escaped chars string
- | c* [string]      Same as above, but printing r2 commands
- | c4 [value]       Compare a doubleword from a math expression
- | c8 [value]       Compare a quadword from a math expression
- | cat [file]       Show contents of file (see pwd, ls)
- | cc [at]          Compares in two hexdump columns of block size
- | ccc [at]         Same as above, but only showing different lines
- | ccd [at]         Compares in two disasm columns of block size
- | cf [file]        Compare contents of file at current seek
- | cg[?] [o] [file] Graphdiff current file and [file]
- | cu[?] [addr] @at Compare memory hexdumps of $$ and dst in unified diff
- | cud [addr] @at   Unified diff disasm from $$ and given address
- | cv[1248] [hexpairs] @at  Compare 1,2,4,8-byte value
- | cV[1248] [addr] @at      Compare 1,2,4,8-byte address contents
- | cw[?] [us?] [...]        Compare memory watchers
- | cx [hexpair]    Compare hexpair string (use '.' as nibble wildcard)
- | cx* [hexpair]   Compare hexpair string (output r2 commands)
- | cX [addr]       Like 'cc' but using hexdiff output
- | cd [dir]        chdir
- | cl|cls|clear    Clear screen, (clear0 to goto 0, 0 only)
+Usage: c[?dfx] [argument]   # Compare
+| c [string]               Compare a plain with escaped chars string
+| c* [string]              Same as above, but printing r2 commands instead
+| c1 [addr]                Compare 8 bits from current offset
+| c2 [value]               Compare a word from a math expression
+| c4 [value]               Compare a doubleword from a math expression
+| c8 [value]               Compare a quadword from a math expression
+| cat [file]               Show contents of file (see pwd, ls)
+| cc [at]                  Compares in two hexdump columns of block size
+| ccc [at]                 Same as above, but only showing different lines
+| ccd [at]                 Compares in two disasm columns of block size
+| ccdd [at]                Compares decompiler output (e cmd.pdc=pdg|pdd)
+| cf [file]                Compare contents of file at current seek
+| cg[?] [o] [file]         Graphdiff current file and [file]
+| cu[?] [addr] @at         Compare memory hexdumps of $$ and dst in unified diff
+| cud [addr] @at           Unified diff disasm from $$ and given address
+| cv[1248] [hexpairs] @at  Compare 1,2,4,8-byte (silent return in $?)
+| cV[1248] [addr] @at      Compare 1,2,4,8-byte address contents (silent, return in $?)
+| cw[?] [us?] [...]        Compare memory watchers
+| cx [hexpair]             Compare hexpair string (use '.' as nibble wildcard)
+| cx* [hexpair]            Compare hexpair string (output r2 commands)
+| cX [addr]                Like 'cc' but using hexdiff output
+| cd [dir]                 chdir
+| cl|cls|clear             Clear screen, (clear0 to goto 0, 0 only)
 ```
 
 To compare memory contents at current seek position against a given string of values, use `cx`:

--- a/basic_commands/seeking.md
+++ b/basic_commands/seeking.md
@@ -38,27 +38,33 @@ Here's the full help of the `s` command. We will explain in more detail below.
 
 ```
 [0x00000000]> s?
-Usage: s[+-] [addr]
-s                 print current address
-s 0x320           seek to this address
-s-                undo seek
-s+                redo seek
-s*                list undo seek history
-s++               seek blocksize bytes forward
-s--               seek blocksize bytes backward
-s+ 512            seek 512 bytes forward
-s- 512            seek 512 bytes backward
-sg/sG             seek begin (sg) or end (sG) of section or file
-s.hexoff          Seek honoring a base from core->offset
-sa [[+-]a] [asz]  seek asz (or bsize) aligned to addr
-sn/sp             seek next/prev scr.nkey
-s/ DATA           search for next occurrence of 'DATA'
-s/x 9091          search for next occurrence of \x90\x91
-sb                seek aligned to bb start
-so [num]          seek to N next opcode(s)
-sf                seek to next function (f->addr+f->size)
-sC str            seek to comment matching given string
-sr pc             seek to register
+Usage: s    # Help for the seek commands. See ?$? to see all variables
+| s                 Print current address
+| s.hexoff          Seek honoring a base from core->offset
+| s:pad             Print current address with N padded zeros (defaults to 8)
+| s addr            Seek to address
+| s-                Undo seek
+| s-*               Reset undo seek history
+| s- n              Seek n bytes backward
+| s--[n]            Seek blocksize bytes backward (/=n)
+| s+                Redo seek
+| s+ n              Seek n bytes forward
+| s++[n]            Seek blocksize bytes forward (/=n)
+| s[j*=!]           List undo seek history (JSON, =list, *r2, !=names, s==)
+| s/ DATA           Search for next occurrence of 'DATA'
+| s/x 9091          Search for next occurrence of \x90\x91
+| sa [[+-]a] [asz]  Seek asz (or bsize) aligned to addr
+| sb                Seek aligned to bb start
+| sC[?] string      Seek to comment matching given string
+| sf                Seek to next function (f->addr+f->size)
+| sf function       Seek to address of specified function
+| sf.               Seek to the beginning of current function
+| sg/sG             Seek begin (sg) or end (sG) of section or file
+| sl[?] [+-]line    Seek to line
+| sn/sp ([nkey])    Seek to next/prev location, as specified by scr.nkey
+| so [N]            Seek to N next opcode(s)
+| sr pc             Seek to register
+| ss                Seek silently (without adding an entry to the seek history)
 
 > 3s++        ; 3 times block-seeking
 > s 10+0x80   ; seek at 0x80+10

--- a/basic_commands/types.md
+++ b/basic_commands/types.md
@@ -4,25 +4,32 @@ Radare2 can also work with data types. You can use standard C data types or defi
 
 ```
 [0x00000000]> t?
-|Usage: t # cparse types commands
-| t                       List all loaded types
-| t <type>                Show type in 'pf' syntax
-| t*                      List types info in r2 commands
-| t- <name>               Delete types by its name
-| t-*                     Remove all types
-| tb <enum> <value>       Show matching enum bitfield for given number
-| te                      List all loaded enums
-| te <enum> <value>       Show name for given enum number
-| td <string>             Load types from string
-| tf                      List all loaded functions signatures
-| tk <sdb-query>          Perform sdb query
-| tl[?]                   Show/Link type to an address
-| to -                    Open cfg.editor to load types
-| to <path>               Load types from C header file
-| tp <type>  = <address>  cast data at <address> to <type> and print it
-| ts                      print loaded struct types
-| tu                      print loaded union types
-[0x00000000]> 
+Usage: t   # cparse types commands
+| t                          List all loaded types
+| tj                         List all loaded types as json
+| t <type>                   Show type in 'pf' syntax
+| t*                         List types info in r2 commands
+| t- <name>                  Delete types by its name
+| t-*                        Remove all types
+| tail [filename]            Output the last part of files
+| tc [type.name]             List all/given types in C output format
+| te[?]                      List all loaded enums
+| td[?] <string>             Load types from string
+| tf                         List all loaded functions signatures
+| tk <sdb-query>             Perform sdb query
+| tl[?]                      Show/Link type to an address
+| tn[?] [-][addr]            manage noreturn function attributes and marks
+| to -                       Open cfg.editor to load types
+| to <path>                  Load types from C header file
+| toe [type.name]            Open cfg.editor to edit types
+| tos <path>                 Load types from parsed Sdb database
+| tp  <type> [addr|varname]  cast data at <address> to <type> and print it (XXX: type can contain spaces)
+| tpv <type> @ [value]       Show offset formatted for given type
+| tpx <type> <hexpairs>      Show value for type with specified byte sequence (XXX: type can contain spaces)
+| ts[?]                      Print loaded struct types
+| tu[?]                      Print loaded union types
+| tx[f?]                     Type xrefs
+| tt[?]                      List all loaded typedefs
 ```
 
 ### Defining new types

--- a/basic_commands/write.md
+++ b/basic_commands/write.md
@@ -12,33 +12,34 @@ Write bytes using the `w` command. It accepts multiple input formats like inline
 
 ```
 [0x00404888]> w?
-|Usage: w[x] [str] [<file] [<<EOF] [@addr]
+Usage: w[x] [str] [<file] [<<EOF] [@addr]  
 | w[1248][+-][n]       increment/decrement byte,word..
 | w foobar             write string 'foobar'
 | w0 [len]             write 'len' bytes with value 0x00
 | w6[de] base64/hex    write base64 [d]ecoded or [e]ncoded string
-| wa[?] push ebp       write opcode, separated by ';'
-| waf file             assemble file and write bytes
-| wao[?] op            modify opcode (conditional jump. nop, etc)
-| wA[?] r 0            alter/modify opcode at current seek (wA?)
+| wa[?] push ebp       write opcode, separated by ';' (use '"' around the command)
+| waf f.asm            assemble file and write bytes
+| waF f.asm            assemble file and write bytes and show 'wx' op with hexpair bytes of assembled code
+| wao[?] op            modify opcode (change conditional of jump. nop, etc)
+| wA[?] r 0            alter/modify opcode at current seek (see wA?)
 | wb 010203            fill current block with cyclic hexpairs
 | wB[-]0xVALUE         set or unset bits with given value
 | wc                   list all write changes
-| wc[?][ir*?]          write cache undo/commit/reset/list (io.cache)
-| wd [off] [n]         duplicate N bytes from offset to here
-| we[?] [nNsxX] [arg]  extend write operations (insert vs replace)
-| wf -|file            write contents of file at current offset
+| wc[?][jir+-*?]       write cache undo/commit/reset/list (io.cache)
+| wd [off] [n]         duplicate N bytes from offset at current seek (memcpy) (see y?)
+| we[?] [nNsxX] [arg]  extend write operations (insert instead of replace)
+| wf[fs] -|file        write contents of file at current offset
 | wh r2                whereis/which shell command
-| wm f0ff              set cyclick binary write mask hexpair
+| wm f0ff              set binary mask hexpair to be used as cyclic write mask
 | wo[?] hex            write in block with operation. 'wo?' fmi
 | wp[?] -|file         apply radare patch file. See wp? fmi
 | wr 10                write 10 random bytes
 | ws pstring           write 1 byte for length and then the string
-| wt[f][?] file [sz]   write to file (from current seek, blocksize)
+| wt[f][?] file [sz]   write to file (from current seek, blocksize or sz bytes)
 | wts host:port [sz]   send data to remote host:port via tcp://
-| ww foobar            write wide string
+| ww foobar            write wide string 'f\x00o\x00o\x00b\x00a\x00r\x00'
 | wx[?][fs] 9090       write two intel nops (from wxfile or wxseek)
-| wv[?] eip+34         write 32-64 bit value
+| wv[?] eip+34         write 32-64 bit value honoring cfg.bigendian
 | wz string            write zero terminated string (like w + \x00)
 ```
 

--- a/basic_commands/yank_paste.md
+++ b/basic_commands/yank_paste.md
@@ -15,20 +15,27 @@ You can yank/paste bytes in visual mode selecting them with the cursor mode (`Vc
 
 ```
 [0x00000000]> y?
-|Usage: y[ptxy] [len] [[@]addr] # See wd? for memcpy, same as 'yf'.
-| y              show yank buffer information (srcoff len bytes)
-| y 16           copy 16 bytes into clipboard
-| y 16 0x200     copy 16 bytes into clipboard from 0x200
-| y 16 @ 0x200   copy 16 bytes into clipboard from 0x200
-| yz [len]       copy string (from current block) into clipboard
-| yp             print contents of clipboard
-| yx             print contents of clipboard in hexadecimal
-| ys             print contents of clipboard as string
-| yt 64 0x200    copy 64 bytes from current seek to 0x200
-| ytf file       dump the clipboard to given file
-| yf 64 0x200    copy 64 bytes from 0x200 from file
-| yfa file copy  copy all bytes from file (opens w/ io)
-| yy 0x3344      paste clipboard
+Usage: y[ptxy] [len] [[@]addr]   # See wd? for memcpy, same as 'yf'.
+| y!              open cfg.editor to edit the clipboard
+| y 16 0x200      copy 16 bytes into clipboard from 0x200
+| y 16 @ 0x200    copy 16 bytes into clipboard from 0x200
+| y 16            copy 16 bytes into clipboard
+| y               show yank buffer information (srcoff len bytes)
+| y*              print in r2 commands what's been yanked
+| yf 64 0x200     copy file 64 bytes from 0x200 from file
+| yfa file copy   copy all bytes from file (opens w/ io)
+| yfx 10203040    yank from hexpairs (same as ywx)
+| yj              print in JSON commands what's been yanked
+| yp              print contents of clipboard
+| yq              print contents of clipboard in hexpairs
+| ys              print contents of clipboard as string
+| yt 64 0x200     copy 64 bytes from current seek to 0x200
+| ytf file        dump the clipboard to given file
+| yw hello world  yank from string
+| ywx 10203040    yank from hexpairs (same as yfx)
+| yx              print contents of clipboard in hexadecimal
+| yy 0x3344       paste clipboard
+| yz [len]        copy nul-terminated string (up to blocksize) into clipboard
 ```
 
 Sample session:

--- a/configuration/colors.md
+++ b/configuration/colors.md
@@ -27,4 +27,6 @@ Type `ec` to get a list of all currently used colors. Type `ecs` to show a color
 
 You can create your own color theme, but radare2 have its own predefined ones. Use the `eco` command to list or select them.
 
+After selecting one, you can compare between the color scheme of the shell and the current theme by pressing Ctrl-Shift and then right arrow key for the toggle.
+
 In visual mode use the `R` key to randomize colors or choose the next theme in the list.

--- a/configuration/intro.md
+++ b/configuration/intro.md
@@ -22,19 +22,28 @@ prompt. To limit the output to a selected namespace, pass it with an ending dot 
 To get help about `e` command type `e?`:
 
 ```
-Usage: e[?] [var[=value]]
-e?              show this help
-e?asm.bytes     show description
-e??             list config vars with description
-e               list config vars
-e-              reset config vars
-e*              dump config vars in r commands
-e!a             invert the boolean value of 'a' var
-er [key]        set config key as readonly. no way back
-ec [k] [color]  set color for given key (prompt, offset, ...)
-e a             get value of var 'a'
-e a=b           set var 'a' the 'b' value
-env [k[=v]]     get/set environment variable
+Usage: e [var[=value]]  Evaluable vars
+| e?asm.bytes     show description
+| e??             list config vars with description
+| e a             get value of var 'a'
+| e a=b           set var 'a' the 'b' value
+| e var=?         print all valid values of var
+| e var=??        print all valid values of var with description
+| e.a=b           same as 'e a=b' but without using a space
+| e,k=v,k=v,k=v   comma separated k[=v]
+| e-              reset config vars
+| e*              dump config vars in r commands
+| e!a             invert the boolean value of 'a' var
+| ec [k] [color]  set color for given key (prompt, offset, ...)
+| eevar           open editor to change the value of var
+| ed              open editor to change the ~/.radare2rc
+| ej              list config vars in JSON
+| env [k[=v]]     get/set environment variable
+| er [key]        set config key as readonly. no way back
+| es [space]      list all eval spaces [or keys]
+| et [key]        show type of given config variable
+| ev [key]        list config vars in verbose format
+| evj [key]       list config vars in verbose format in JSON
 ```
 
 A simpler alternative to the `e` command is accessible from the visual mode. Type `Ve` to enter it, use arrows (up, down, left, right) to navigate the configuration, and `q` to exit it. The start screen for the visual configuration edit looks like this:

--- a/debugger/memory_maps.md
+++ b/debugger/memory_maps.md
@@ -6,27 +6,28 @@ First, let's see the help message for `dm`, the command which is responsible for
 
 ```
 [0x55f2104cf620]> dm?
-|Usage: dm # Memory maps commands
-| dm              List memory maps of target process
-| dm addr size    Allocate <size> bytes at <address> (anywhere if address is -1) in child process
-| dm=             List memory maps of target process (ascii-art bars)
-| dm.             Show map name of current address
-| dm*             List memmaps in radare commands
-| dm- address     Deallocate memory map of <address>
-| dmd[a] [file]   Dump current (all) debug map region to a file (from-to.dmp) (see Sd)
-| dmh[?]          Show map of heap
-| dmi.            List closest symbol to the current address
-| dmiv            Show address of given symbol for given lib
-| dmj             List memmaps in JSON format
-| dml <file>      Load contents of file into the current map region (see Sl)
-| dmm[?][j*]      List modules (libraries, binaries loaded in memory)
+Usage: dm   # Memory maps commands
+| dm                               List memory maps of target process
+| dm address size                  Allocate <size> bytes at <address> (anywhere if address is -1) in child process
+| dm=                              List memory maps of target process (ascii-art bars)
+| dm.                              Show map name of current address
+| dm*                              List memmaps in radare commands
+| dm- address                      Deallocate memory map of <address>
+| dmd[a] [file]                    Dump current (all) debug map region to a file (from-to.dmp) (see Sd)
+| dmh[?]                           Show map of heap
 | dmi [addr|libname] [symname]     List symbols of target lib
 | dmi* [addr|libname] [symname]    List symbols of target lib in radare commands
-| dmp[?] <address> <size> <perms>  Change page at <address> with <size>, protection <perms> (rwx)
+| dmi.                             List closest symbol to the current address
+| dmiv                             Show address of given symbol for given lib
+| dmj                              List memmaps in JSON format
+| dml <file>                       Load contents of file into the current map region
+| dmm[?][j*]                       List modules (libraries, binaries loaded in memory)
+| dmp[?] <address> <size> <perms>  Change page at <address> with <size>, protection <perms> (perm)
 | dms[?] <id> <mapaddr>            Take memory snapshot
 | dms- <id> <mapaddr>              Restore memory snapshot
 | dmS [addr|libname] [sectname]    List sections of target lib
 | dmS* [addr|libname] [sectname]   List sections of target lib in radare commands
+| dmL address size                 Allocate <size> bytes at <address> and promote to huge page
 ```
 
 In this chapter, we'll go over some of the most useful subcommands of `dm` using simple examples. For the following examples, we'll use a simple `helloworld` program for Linux but it'll be the same for every binary.

--- a/debugger/remoting_capabilities.md
+++ b/debugger/remoting_capabilities.md
@@ -7,27 +7,35 @@ Help for commands useful for remote access to radare:
 
 ```
 [0x00405a04]> =?
-|Usage:  =[:!+-=hH] [...] # radare remote command execution protocol
-|
-rap commands:
-| =           list all open connections
-| =<[fd] cmd  send output of local command to remote fd
-| =[fd] cmd   exec cmd at remote 'fd' (last open is default one)
-| =! cmd      run command via r_io_system
-| =+ [proto://]host  add host (default=rap://, tcp://, udp://)
-| =-[fd]      remove all hosts or host 'fd'
-| ==[fd]      open remote session with host 'fd', 'q' to quit
-| =!=         disable remote cmd mode
-| !=!         enable remote cmd mode
-|
-rap server:
-| =:port      listen on given port using rap protocol (o rap://9999)
-| =&:port     start rap server in background
-| =:host:port run 'cmd' command on remote server
-|
-other servers:
-| =h[?]       listen for http connections
-| =g[?]       using gdbserver
+Usage:  =[:!+-=ghH] [...]   # connect with other instances of r2
+
+remote commands:
+| =                             list all open connections
+| =<[fd] cmd                    send output of local command to remote fd
+| =[fd] cmd                     exec cmd at remote 'fd' (last open is default one)
+| =! cmd                        run command via r_io_system
+| =+ [proto://]host:port        connect to remote host:port (*rap://, raps://, tcp://, udp://, http://)
+| =-[fd]                        remove all hosts or host 'fd'
+| ==[fd]                        open remote session with host 'fd', 'q' to quit
+| =!=                           disable remote cmd mode
+| !=!                           enable remote cmd mode
+
+servers:
+| .:9000                        start the tcp server (echo x|nc ::1 9090 or curl ::1:9090/cmd/x)
+| =:port                        start the rap server (o rap://9999)
+| =g[?]                         start the gdbserver
+| =h[?]                         start the http webserver
+| =H[?]                         start the http webserver (and launch the web browser)
+
+other:
+| =&:port                       start rap server in background (same as '&_=h')
+| =:host:port cmd               run 'cmd' command on remote server
+
+examples:
+| =+tcp://localhost:9090/       connect to: r2 -c.:9090 ./bin
+| =+rap://localhost:9090/       connect to: r2 rap://:9090
+| =+http://localhost:9090/cmd/  connect to: r2 -c'=h 9090' bin
+| o rap://:9090/                start the rap server on tcp port 9090
 ```
 
 You can learn radare2 remote capabilities by displaying the list of supported IO plugins: `radare2 -L`.

--- a/disassembling/adding_metadata.md
+++ b/disassembling/adding_metadata.md
@@ -22,27 +22,32 @@ There are many different metadata manipulation commands, here is the glimpse of 
 
 ```
 [0x00404cc0]> C?
-|Usage: C[-LCvsdfm*?][*?] [...] # Metadata management
-| C                            list meta info in human friendly form
-| C*                           list meta info in r2 commands
-| C[Chsdmf]                    list comments/hidden/strings/data/magic/formatted in human friendly form
-| C[Chsdmf]*                   list comments/hidden/strings/data/magic/formatted in r2 commands
-| C- [len] [[@]addr]           delete metadata at given address range
-| CL[-][*] [file:line] [addr]  show or add 'code line' information (bininfo)
-| CS[-][space]                 manage meta-spaces to filter comments, etc..
-| CC[?] [-] [comment-text] [@addr] add/remove comment
-| CC.[addr]                    show comment in current address
-| CC! [@addr]                  edit comment with $EDITOR
-| CCa[-at]|[at] [text] [@addr] add/remove comment at given address
-| CCu [comment-text] [@addr]   add unique comment
-| Cv[bsr][?]                   add comments to args
-| Cs[?] [-] [size] [@addr]     add string
-| Cz[@addr]                    add string (see Cs?)
-| Ch[-] [size] [@addr]         hide data
-| Cd[-] [size] [repeat] [@addr]hexdump data array (Cd 4 10 == dword [10])
+| Usage: C[-LCvsdfm*?][*?] [...]   # Metadata management
+| C                                              list meta info in human friendly form
+| C*                                             list meta info in r2 commands
+| C*.                                            list meta info of current offset in r2 commands
+| C- [len] [[@]addr]                             delete metadata at given address range
+| C.                                             list meta info of current offset in human friendly form
+| CC! [@addr]                                    edit comment with $EDITOR
+| CC[?] [-] [comment-text] [@addr]               add/remove comment
+| CC.[addr]                                      show comment in current address
+| CCa[-at]|[at] [text] [@addr]                   add/remove comment at given address
+| CCu [comment-text] [@addr]                     add unique comment
+| CF[sz] [fcn-sign..] [@addr]                    function signature
+| CL[-][*] [file:line] [addr]                    show or add 'code line' information (bininfo)
+| CS[-][space]                                   manage meta-spaces to filter comments, etc..
+| C[Cthsdmf]                                     list comments/types/hidden/strings/data/magic/formatted in human friendly form
+| C[Cthsdmf]*                                    list comments/types/hidden/strings/data/magic/formatted in r2 commands
+| Cd[-] [size] [repeat] [@addr]                  hexdump data array (Cd 4 10 == dword [10])
+| Cd. [@addr]                                    show size of data at current address
 | Cf[?][-] [sz] [0|cnt][fmt] [a0 a1...] [@addr]  format memory (see pf?)
-| CF[sz] [fcn-sign..] [@addr]  function signature
-| Cm[-] [sz] [fmt..] [@addr]   magic parse (see pm?)
+| Ch[-] [size] [@addr]                           hide data
+| Cm[-] [sz] [fmt..] [@addr]                     magic parse (see pm?)
+| Cs[?] [-] [size] [@addr]                       add string
+| Ct[?] [-] [comment-text] [@addr]               add/remove type analysis comment
+| Ct.[@addr]                                     show comment at current or specified address
+| Cv[bsr][?]                                     add comments to args
+| Cz[@addr]                                      add string (see Cs?)
 ```
 
 Simply to add the comment to a particular line/address you can use `Ca` command:

--- a/tools/r2pm/intro.md
+++ b/tools/r2pm/intro.md
@@ -39,7 +39,7 @@ There are many commands available now:
 r2pm -h
 Usage: r2pm [init|update|cmd] [...]
 Commands:
- -i,info                     show information about a package
+ -I,info                     show information about a package
  -i,install <pkgname>        install package in your home (pkgname=all)
  -gi,global-install <pkg>    install package system-wide
  -gu,global-uninstall <pkg>  uninstall pkg from systemdir

--- a/tools/radiff2/intro.md
+++ b/tools/radiff2/intro.md
@@ -3,7 +3,7 @@
 Radiff2 is a tool designed to compare binary files, similar to how regular `diff` compares text files.
 ```
 $ radiff2 -h
-Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-t %] [file] [file]
+Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-m graph_mode][-t %] [file] [file]
   -a [arch]  specify architecture plugin to use (x86, arm, ..)
   -A [-A]    run aaa or aaaa after loading each binary (see -C)
   -b [bits]  specify register size for arch (16 (thumb), 32, 64, ..)
@@ -18,6 +18,7 @@ Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-t %] [file] [file]
   -i         diff imports of target files (see -u, -U and -z)
   -j         output in json format
   -n         print bare addresses only (diff.bare=1)
+  -m [aditsjJ]  choose the graph output mode
   -O         code diffing with opcode bytes only
   -p         use physical addressing (io.va=0)
   -q         quiet mode (disable colors, reduce output)
@@ -27,10 +28,23 @@ Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-t %] [file] [file]
   -S [name]  sort code diff (name, namelen, addr, size, type, dist) (only for -C or -g)
   -t [0-100] set threshold for code diff (default is 70%)
   -x         show two column hexdump diffing
+  -X         show two column hexII diffing
   -u         unified output (---+++)
   -U         unified output using system 'diff'
   -v         show version information
   -V         be verbose (current only for -s)
   -z         diff on extracted strings
+  -Z         diff code comparing zignatures
+
+Graph Output formats: (-m [mode])
+  <blank/a>  Ascii art
+  s          r2 commands
+  d          Graphviz dot
+  g          Graph Modelling Language (gml)
+  j          json
+  J          json with disarm
+  k          SDB key-value
+  t          Tiny ascii art
+  i          Interactive ascii art
 ```
 

--- a/tools/rafind2/intro.md
+++ b/tools/rafind2/intro.md
@@ -4,19 +4,20 @@ Rafind2 is the command line fronted of the `r_search` library. Which allows you 
 
 ```
 $ rafind2 -h
-Usage: rafind2 [-mXnzZhqv] [-a align] [-b sz] [-f/t from/to] [-[e|s|S] str] [-x hex] file|dir ..
+Usage: rafind2 [-mXnzZhqv] [-a align] [-b sz] [-f/t from/to] [-[e|s|S] str] [-x hex] -|file|dir ..
  -a [align] only accept aligned hits
  -b [size]  set block size
  -e [regex] search for regex matches (can be used multiple times)
  -f [from]  start searching from address 'from'
  -h         show this help
  -i         identify filetype (r2 -nqcpm file)
+ -j         output in JSON
  -m         magic search, file-type carver
  -M [str]   set a binary mask to be applied on keywords
  -n         do not stop on read errors
  -r         print using radare commands
  -s [str]   search for a specific string (can be used multiple times)
- -S [str]   search for a specific wide string (can be used multiple times)
+ -S [str]   search for a specific wide string (can be used multiple times). Assumes str is UTF-8.
  -t [to]    stop search at address 'to'
  -q         quiet - do not show headings (filenames) above matching contents (default for searching a single file)
  -v         print version and exit


### PR DESCRIPTION
**Detailed description**
 
Updated most of the outdated command hints of various radare2 commands.

**Changes**
* Updated command hints in types.md, basic_commands.md, memory_maps.md, adding_metadata,md, intro.md in configuration, remoting_capabilities.md and the help of radiff2, r2pm and rafind2.
* Added info on toggling between themes in colors.md

---

My radare2 version is : 
```
radare2 4.5.0-git 24795 @ linux-x86-64 git.4.4.0-239-g9de7c2e8d
commit: 9de7c2e8dde62c43afd098dbf22787d364950d27 build: 2020-06-04__22:25:02
```