### PR TITLE
fix r2pipe rust example (serde_json)

### DIFF
--- a/src/scripting/r2pipe.md
+++ b/src/scripting/r2pipe.md
@@ -124,8 +124,8 @@ fn main() {
   let mut r2p = open_pipe!(Some("/bin/ls")).unwrap();
   println!("{:?}", r2p.cmd("?e Hello World"));
   let json = r2p.cmdj("ij").unwrap();
-  println!("{}", json.pretty());
-  println!("ARCH {}", json.find_path(&["bin","arch"]).unwrap());
+  println!("{}", serde_json::to_string_pretty(&json).unwrap());
+  println!("ARCH {}", json["bin"]["arch"]);
   r2p.close();
 }
 ```


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

The rust example for r2pipe was throwing the following compilation error:
```
error[E0599]: no method named `pretty` found for enum `serde_json::value::Value` in the current scope
 --> src/main.rs:8:23
  |
8 |   println!("{}", json.pretty());
  |                       ^^^^^^ method not found in `serde_json::value::Value`

error[E0599]: no method named `find_path` found for enum `serde_json::value::Value` in the current scope
 --> src/main.rs:9:28
  |
9 |   println!("ARCH {}", json.find_path(&["bin","arch"]).unwrap());
  |                            ^^^^^^^^^ method not found in `serde_json::value::Value`

error: aborting due to 2 previous errors
```
Looks like rust r2pipe switched the json lib

from
- https://doc.rust-lang.org/1.1.0/serialize/json/enum.Json.html

to
- https://docs.serde.rs/serde_json/ 

