### PR TITLE
Fix links from not being links when rendered by mdbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,5 @@ updated by many contributors over the Internet.
 
 Check the Github site to add new contents or fix typos:
 
-* Github: https://github.com/radareorg/radare2book
-* Online: https://book.rada.re/
-
+* Github: [https://github.com/radareorg/radare2book](https://github.com/radareorg/radare2book)
+* Online: [https://book.rada.re/](https://book.rada.re/)

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,5 @@ updated by many contributors over the Internet.
 
 Check the Github site to add new contents or fix typos:
 
-* Github: https://github.com/radareorg/radare2book
-* Online: https://radareorg.github.io/radare2book/index.html
-
+* Github: [https://github.com/radareorg/radare2book](https://github.com/radareorg/radare2book)
+* Online: [https://book.rada.re/](https://book.rada.re/)

--- a/src/intro.md
+++ b/src/intro.md
@@ -6,6 +6,5 @@ updated by many contributors over the Internet.
 
 Check the Github site to add new contents or fix typos:
 
-* Github: https://github.com/radareorg/radare2book
-* Online: https://radareorg.github.io/radare2book/index.html
-
+* Github: [https://github.com/radareorg/radare2book](https://github.com/radareorg/radare2book)
+* Online: [https://book.rada.re/](https://book.rada.re/)


### PR DESCRIPTION
**Detailed description**

Introduction page shows links in plain text at https://book.rada.re/,
it also points to the full github.io GitHub Pages URL. Both problems
are now fixed by this commit.

**Test plan**

None

**Closing issues**

None