### PR TITLE
block_size: Fix command on `bf; pd/pD` and rewording

### DIFF
--- a/src/basic_commands/block_size.md
+++ b/src/basic_commands/block_size.md
@@ -3,9 +3,8 @@
 The block size determines how many bytes radare2 commands will process when not given an explicit size argument. You can temporarily change the block size by specifying a numeric argument to the print commands. For example `px 20`.
 
 ```
-[0xB7F9D810]> b?
-| Usage: b[f] [arg]
-| Get/Set block size
+[0x00000000]> b?
+Usage: b[f] [arg]  # Get/Set block size
 | b 33     set block size to 33
 | b eip+4  numeric argument can be an expression
 | b        display current block size
@@ -20,21 +19,35 @@ The block size determines how many bytes radare2 commands will process when not 
 The `b` command is used to change the block size:
 
 ```
-[0x00000000]> b 0x100   ; block size = 0x100
-[0x00000000]> b+16      ;  ... = 0x110
-[0x00000000]> b-32      ;  ... = 0xf0
+[0x00000000]> b 0x100   # block size = 0x100
+[0x00000000]> b+16      #  ... = 0x110
+[0x00000000]> b-32      #  ... = 0xf0
 ```
 
-The `bf` command is used to change the block size to value specified by a flag. For example, in symbols, the block size of the flag represents the size of the function.
+The `bf` command is used to change the block size to value specified by a flag. For example, in symbols, the block size of the flag represents the size of the function. To make that work, you have to either run function analysis `af` (which is included in `aa`) or manually seek and define some functions e.g. via `Vd`.
+
 ```
-[0x00000000]> bf sym.main    ; block size = sizeof(sym.main)
-[0x00000000]> pd @ sym.main  ; disassemble sym.main
+[0x00000000]> bf sym.main    # block size = sizeof(sym.main)
+[0x00000000]> pD @ sym.main  # disassemble sym.main
+```
+
+You can combine two operations in a single `pdf` command. Except that `pdf` neither uses nor affects global block size.
+
+```
+[0x00000000]> pdf @ sym.main  # disassemble sym.main
+```
+
+Another way around is to use special variables `$FB` and `$FS` which denote Function's Beginning and Size at the current seek. Read more about [Usable variables](../refcard/intro.md#usable-variables-in-expression).
+
+```
+[0x00000000]> s sym.main + 0x04
+[0x00001ec9]> pD @ $FB !$FS  # disassemble current function
+╭ 211: int main (int argc, char **argv, char **envp);
+│           0x00001ec5      55                 push rbp
+│           0x00001ec6      4889e5             mov rbp, rsp
+│           0x00001ec9      4881ecc0000000     sub rsp, 0xc0
 ...
+╰           0x00001f97      c3                 ret
 ```
 
-You can combine two operations in a single one (`pdf`):
-
-```
-[0x00000000]> pdf @ sym.main
-```
-
+Note: don't put space after `!` size designator. See also [Command Format](../first_steps/command_format.md).


### PR DESCRIPTION
**Detailed description**

`pd` operates on opcodes, `pD` operates on bytes. Later makes more sense
when talking about  block size.

Also, `bf <...>; pD @ <...>` is not an exact equivalent of `pdf`,
since `pdf` does not change block size globally -- I doubt if it takes
block size into consideration at all.

**Test plan**

None

**Closing issues**

None