### PR TITLE
Remove citation to http://bin.rada.re/

### DIFF
--- a/src/first_steps/getting_radare.md
+++ b/src/first_steps/getting_radare.md
@@ -1,12 +1,11 @@
 ## Downloading radare2
 
-You can get radare from the website, [http://radare.org](http://radare.org),
-or the GitHub repository: [https://github.com/radareorg/radare2](https://github.com/radareorg/radare2)
+You can get radare from the GitHub repository: [https://github.com/radareorg/radare2](https://github.com/radareorg/radare2)
 
 
 Binary packages are available for a number of operating systems (Ubuntu, Maemo, Gentoo, Windows, iPhone, and so on). But you are highly encouraged to get the source and compile it yourself to better understand the dependencies, to make examples more accessible and, of course, to have the most recent version.
 
-A new stable release is typically published every month. Nightly tarballs are sometimes available at [http://bin.rada.re/](http://bin.rada.re/).
+A new stable release is typically published every month.
 
 The radare development repository is often more stable than the 'stable' releases. To obtain the latest version:
 ```


### PR DESCRIPTION
**Detailed description**

Remove from  "Downloading radare2" in radare2book any citation to http://bin.rada.re/ as it is no more used.
Official binaries are now available in Github
Nightly builds are available as artefacts in GitHub Actions  
...

**Test plan**

Regenerate radare2bool

**Closing issues**

...
