### PR TITLE
Fix `evertyhing` -> `everything` typo in r2fwrev setup example

### DIFF
--- a/src/r2fwrev/setup.md
+++ b/src/r2fwrev/setup.md
@@ -15,7 +15,7 @@ all:
 $ cat script.r2
 f entry0=0x8005320
 s entry0
-CC evertyhing starts here
+CC everything starts here
 afr
 ```
 


### PR DESCRIPTION
Line 18 of `src/r2fwrev/setup.md` has `CC evertyhing starts here` (transposed letters) inside a radare2 `CC` (comment) command example. Fixed to `everything`.